### PR TITLE
#172: Prevent the user from adding more than one wallet with the same seed

### DIFF
--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MatDialogModule } from '@angular/material';
+import { MatDialogModule, MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormBuilder } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -29,7 +29,8 @@ describe('OnboardingCreateWalletComponent', () => {
       imports: [
         MatDialogModule,
         RouterTestingModule,
-        BrowserAnimationsModule
+        BrowserAnimationsModule,
+        MatSnackBarModule
       ],
       providers: [
         FormBuilder,

--- a/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
+++ b/src/app/components/pages/onboarding/onboarding-create-wallet/onboarding-create-wallet.component.ts
@@ -3,6 +3,8 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import * as Bip39 from 'bip39';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material';
+
 import { WalletService } from '../../../../services/wallet.service';
 import { DoubleButtonActive } from '../../../layout/double-button/double-button.component';
 import { OnboardingDisclaimerComponent } from './onboarding-disclaimer/onboarding-disclaimer.component';
@@ -24,6 +26,7 @@ export class OnboardingCreateWalletComponent implements OnInit {
     private walletService: WalletService,
     private router: Router,
     private formBuilder: FormBuilder,
+    private snackBar: MatSnackBar
   ) { }
 
   ngOnInit() {
@@ -93,13 +96,25 @@ export class OnboardingCreateWalletComponent implements OnInit {
   }
 
   createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
-    this.showSafe();
+    try {
+      this.walletService.create(this.form.value.label, this.form.value.seed);
+      this.showSafe();
+    } catch (exception) {
+      const config = new MatSnackBarConfig();
+      config.duration = 5000;
+      this.snackBar.open(exception.message, null, config);
+    }
   }
 
   loadWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
-    this.skip();
+    try {
+      this.walletService.create(this.form.value.label, this.form.value.seed);
+      this.skip();
+    } catch (exception) {
+      const config = new MatSnackBarConfig();
+      config.duration = 5000;
+      this.snackBar.open(exception.message, null, config);
+    }
   }
 
   skip() {

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef, MatSnackBarModule } from '@angular/material';
 
 import { CreateWalletComponent } from './create-wallet.component';
 import { WalletService } from '../../../../services/wallet.service';
@@ -16,6 +16,7 @@ describe('CreateWalletComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CreateWalletComponent ],
+      imports: [ MatSnackBarModule ],
       schemas: [ NO_ERRORS_SCHEMA ],
       providers: [
         FormBuilder,

--- a/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
+++ b/src/app/components/pages/wallets/create-wallet/create-wallet.component.ts
@@ -2,9 +2,9 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import * as Bip39 from 'bip39';
+import { MAT_DIALOG_DATA, MatSnackBarConfig, MatSnackBar } from '@angular/material';
 
 import { WalletService } from '../../../../services/wallet.service';
-import { MAT_DIALOG_DATA } from '@angular/material';
 
 @Component({
   selector: 'app-create-wallet',
@@ -20,6 +20,7 @@ export class CreateWalletComponent implements OnInit {
     public dialogRef: MatDialogRef<CreateWalletComponent>,
     private walletService: WalletService,
     private formBuilder: FormBuilder,
+    private snackBar: MatSnackBar
   ) { }
 
   ngOnInit() {
@@ -31,8 +32,14 @@ export class CreateWalletComponent implements OnInit {
   }
 
   createWallet() {
-    this.walletService.create(this.form.value.label, this.form.value.seed);
-    this.dialogRef.close();
+    try {
+      this.walletService.create(this.form.value.label, this.form.value.seed);
+      this.dialogRef.close();
+    } catch (exception) {
+      const config = new MatSnackBarConfig();
+      config.duration = 5000;
+      this.snackBar.open(exception.message, null, config);
+    }
   }
 
   generateSeed() {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -65,8 +65,15 @@ export class WalletService {
       seed: seed,
       addresses: [this.cipherProvider.generateAddress(this.ascii_to_hexa(seed))]
     };
-    this.addWallet(wallet);
-    this.loadBalances();
+
+    this.all.first().subscribe((wallets: Wallet[]) => {
+      if (wallets.some((w: Wallet) => w.addresses[0].address === wallet.addresses[0].address)) {
+        throw new Error('trying to add an existing wallet!');
+      }
+
+      this.addWallet(wallet);
+      this.loadBalances();
+    });
   }
 
   sendSkycoin(wallet: Wallet, address: string, amount: number) {


### PR DESCRIPTION
Fixes #172

Changes:
- Checking for the wallet existing with the same seed.
- SnackBars were added to display an error.
- New e2e tests were added
